### PR TITLE
【確認待ち】wp_set_script_translationsの実行位置を修正

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -126,6 +126,7 @@ function vbp_admin_enqueue_scripts( $hook_suffix ) {
 		$asset['version'],
 		true
 	);
+	wp_set_script_translations( 'vk-patterns-admin-js', 'vk-block-patterns' );
 
 	// 画面読み込み時に保存値を localize_script を使って渡す.
 	// boolean は 空 '' false または 1 true を渡す.
@@ -133,13 +134,3 @@ function vbp_admin_enqueue_scripts( $hook_suffix ) {
 	wp_localize_script( 'vk-patterns-admin-js', 'vkpOptions', $vbp_options );
 }
 add_action( 'admin_enqueue_scripts', 'vbp_admin_enqueue_scripts' );
-
-/**
- * Add admin js transration
- *
- * @return void
- */
-function vbp_admin_script_translations() {
-	wp_set_script_translations( 'vk-patterns-admin-js', 'vk-block-patterns' );
-}
-add_action( 'init', 'vbp_admin_script_translations' );


### PR DESCRIPTION
## チケットへのリンク
#86

GlotPressの開発者さんの言うとおりに一旦してみようというプルリクです

> I think it will work if you move [this line](https://github.com/vektor-inc/vk-block-patterns/blob/7e74dc95e5aa754b50d86be3f0d4a6932a1e8c58/admin/admin.php#L143) directly [below your wp_enqueue_script() line here](https://github.com/vektor-inc/vk-block-patterns/blob/7e74dc95e5aa754b50d86be3f0d4a6932a1e8c58/admin/admin.php#L122-L128).

https://meta.trac.wordpress.org/ticket/6270#comment:2

## 確認事項
このブランチでFatalエラーなどが発生しないことを確認しました