### PR TITLE
【確認待ち】X-T9 のパターンを追加

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -14,7 +14,7 @@ if ( ! function_exists( 'vbp_setting' ) ) {
 	 * Admin Page Setting.
 	 */
 	function vbp_setting() {
-		$options = get_option( 'vk_block_patterns_options' );
+		$options = vbp_get_options();
 		?>
 		<div id="vk_block_patterns_admin"></div>
 		<?php
@@ -89,6 +89,10 @@ function vkp_show_patterns_register_settings() {
 			'type'    => 'boolean',
 			'default' => false,
 		),
+		'disableXT9Pattern' => array(
+			'type'    => 'boolean',
+			'default' => false,
+		),
 	);
 
 	foreach ( $default_option_settings as $key => $value ) {
@@ -148,6 +152,7 @@ function vbp_admin_enqueue_scripts( $hook_suffix ) {
 	// boolean は 空 '' false または 1 true を渡す.
 	$vbp_options             = vbp_get_options();
 	$vbp_options['adminUrl'] = admin_url();
+	$vbp_options['template'] = get_template();
 	wp_localize_script( 'vk-patterns-admin-js', 'vkpOptions', $vbp_options );
 }
 add_action( 'admin_enqueue_scripts', 'vbp_admin_enqueue_scripts' );

--- a/favorite-patterns/favorite-patterns.php
+++ b/favorite-patterns/favorite-patterns.php
@@ -7,7 +7,7 @@
  * API からデータを読み込み
  */
 function vbp_get_pattern_api_data() {
-    $options    = get_option( 'vk_block_patterns_options' );
+    $options    = vbp_get_options();
     $user_email = ! empty( $options['VWSMail'] ) ? $options['VWSMail'] : '';
     $return = '';
 
@@ -34,50 +34,25 @@ function vbp_get_pattern_api_data() {
 function vbp_register_favorite_patterns() {
     $pattern_api_data = vbp_get_pattern_api_data();
     $current_template = get_template();
+    $options          = vbp_get_options();
     if ( ! empty( $pattern_api_data ) && is_array( $pattern_api_data ) ) {
-        $patterns_data = $pattern_api_data['patterns'];
-        
-        if ( function_exists( 'mb_convert_encoding' ) ) {
-            $patterns_data = mb_convert_encoding( $patterns_data, 'UTF8', 'ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN' );
-        }
-        
-        $patterns = json_decode( $patterns_data, true );
-        register_block_pattern_category(
-            'vk-pattern-favorites',
-            array( 
-                'label' => __( 'Favorites of VK Pattern Library', 'vk-block-patterns' ) 
-            )
-        );
-        if ( ! empty( $patterns ) && is_array( $patterns ) ) {
-            foreach ( $patterns as $pattern ) {
-                 register_block_pattern( 
-                    $pattern['post_name'],
-                    array(
-                        'title'      => $pattern['title'],
-                        'categories' => $pattern['categories'],
-                        'content'    => $pattern['content'],
-                    )
-                );
-            }
-        }
-
-        if ( 'x-t9' === $current_template ) {
-            $patterns_data = $pattern_api_data['x-t9'];
-        
+        if ( ! empty( $pattern_api_data['patterns'] ) ) {
+            $patterns_data = $pattern_api_data['patterns'];
+            
             if ( function_exists( 'mb_convert_encoding' ) ) {
                 $patterns_data = mb_convert_encoding( $patterns_data, 'UTF8', 'ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN' );
             }
             
             $patterns = json_decode( $patterns_data, true );
             register_block_pattern_category(
-                'x-t9',
+                'vk-pattern-favorites',
                 array( 
-                    'label' => __( 'X-T9', 'vk-block-patterns' ) 
+                    'label' => __( 'Favorites of VK Pattern Library', 'vk-block-patterns' ) 
                 )
             );
             if ( ! empty( $patterns ) && is_array( $patterns ) ) {
                 foreach ( $patterns as $pattern ) {
-                     register_block_pattern( 
+                    register_block_pattern( 
                         $pattern['post_name'],
                         array(
                             'title'      => $pattern['title'],
@@ -85,6 +60,37 @@ function vbp_register_favorite_patterns() {
                             'content'    => $pattern['content'],
                         )
                     );
+                }
+            }
+        }
+
+        if ( 'x-t9' === $current_template && false === $options['disableXT9Pattern'] ) {
+            if ( ! empty( $pattern_api_data['x-t9'] ) ) {
+                $patterns_data = $pattern_api_data['x-t9'];
+
+            
+                if ( function_exists( 'mb_convert_encoding' ) ) {
+                    $patterns_data = mb_convert_encoding( $patterns_data, 'UTF8', 'ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN' );
+                }
+                
+                $patterns = json_decode( $patterns_data, true );
+                register_block_pattern_category(
+                    'x-t9',
+                    array( 
+                        'label' => __( 'X-T9', 'vk-block-patterns' ) 
+                    )
+                );
+                if ( ! empty( $patterns ) && is_array( $patterns ) ) {
+                    foreach ( $patterns as $pattern ) {
+                        register_block_pattern( 
+                            $pattern['post_name'],
+                            array(
+                                'title'      => $pattern['title'],
+                                'categories' => $pattern['categories'],
+                                'content'    => $pattern['content'],
+                            )
+                        );
+                    }
                 }
             }
         }

--- a/favorite-patterns/favorite-patterns.php
+++ b/favorite-patterns/favorite-patterns.php
@@ -33,6 +33,7 @@ function vbp_get_pattern_api_data() {
  */
 function vbp_register_favorite_patterns() {
     $pattern_api_data = vbp_get_pattern_api_data();
+    $current_template = get_template();
     if ( ! empty( $pattern_api_data ) && is_array( $pattern_api_data ) ) {
         $patterns_data = $pattern_api_data['patterns'];
         
@@ -57,6 +58,34 @@ function vbp_register_favorite_patterns() {
                         'content'    => $pattern['content'],
                     )
                 );
+            }
+        }
+
+        if ( 'x-t9' === $current_template ) {
+            $patterns_data = $pattern_api_data['x-t9'];
+        
+            if ( function_exists( 'mb_convert_encoding' ) ) {
+                $patterns_data = mb_convert_encoding( $patterns_data, 'UTF8', 'ASCII,JIS,UTF-8,EUC-JP,SJIS-WIN' );
+            }
+            
+            $patterns = json_decode( $patterns_data, true );
+            register_block_pattern_category(
+                'x-t9',
+                array( 
+                    'label' => __( 'X-T9', 'vk-block-patterns' ) 
+                )
+            );
+            if ( ! empty( $patterns ) && is_array( $patterns ) ) {
+                foreach ( $patterns as $pattern ) {
+                     register_block_pattern( 
+                        $pattern['post_name'],
+                        array(
+                            'title'      => $pattern['title'],
+                            'categories' => $pattern['categories'],
+                            'content'    => $pattern['content'],
+                        )
+                    );
+                }
             }
         }
     }

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,8 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Add ][ Japanese ] Add combination with X-T9 Patterns.
+
 = 1.24.2 =
 [ Other ] Admin text tuning
 

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -69,6 +69,7 @@ const Admin = () => {
 	const lang = getLocaleData()[ '' ].lang;
 	// パターン管理画面URL
 	const patternPostTypeUrl = vkpOptions.adminUrl + 'edit.php?post_type=vk-block-patterns';
+	const template           = vkpOptions.template;
 	return (
 		<>
 			<div>
@@ -146,6 +147,23 @@ const Admin = () => {
 						} );
 					} }
 				/>
+				{ lang === 'ja_JP' && vkpOption.VWSMail !== '' && template === 'x-t9' && (
+					<>
+						<ToggleControl
+							label={ __(
+								'Disable X-T9 patterns',
+								'vk-block-patterns'
+							) }
+							checked={ vkpOption.disableXT9Pattern }
+							onChange={ ( newValue ) => {
+								updateOptionValue( {
+									...vkpOption,
+									disableXT9Pattern: newValue,
+								} );
+							} }
+						/>
+					</>
+				)}
 				</section>
 				{ lang === 'ja_JP' && (
 					<>

--- a/tests/test-get-options.php
+++ b/tests/test-get-options.php
@@ -62,7 +62,38 @@ class GetOptionsTest extends WP_UnitTestCase {
 						'disable-empty-notice'   => false,
 						'disable-invalid-notice' => false,
 						'disable-free-notice'    => false,
-					)
+					),
+				),
+			),
+			// X-T9 のパターン読み込みパラメーター追加.
+			// https://github.com/vektor-inc/vk-block-patterns/pull/132
+			array(
+				'option'  => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'account-check'        => array(
+						'date'                   => null,
+						'disable-empty-notice'   => false,
+						'disable-invalid-notice' => false,
+						'disable-free-notice'    => false,
+					),
+				),
+				'correct' => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
+						'date'                   => null,
+						'disable-empty-notice'   => false,
+						'disable-invalid-notice' => false,
+						'disable-free-notice'    => false,
+					),
 				),
 			),
 		);

--- a/tests/test-get-options.php
+++ b/tests/test-get-options.php
@@ -8,6 +8,7 @@
 class GetOptionsTest extends WP_UnitTestCase {
 
 	public function test_vbp_get_options() {
+		// オプション値の追加などがあった場合は $test_data の配列の中のデータを追加してテストを追加してください。
 		$test_data = array(
 			array(
 				'option'  => null,

--- a/tests/test-get-options.php
+++ b/tests/test-get-options.php
@@ -17,6 +17,7 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'VWSMail'              => '',
 					'disableCorePattern'   => false,
 					'disablePluginPattern' => false,
+					'disableXT9Pattern'    => false,
 					'account-check'        => array(
 						'date'                   => null,
 						'disable-empty-notice'   => false,
@@ -35,6 +36,7 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'VWSMail'              => '',
 					'disableCorePattern'   => false,
 					'disablePluginPattern' => false,
+					'disableXT9Pattern'    => false,
 					'account-check'        => array(
 						'date'                   => null,
 						'disable-empty-notice'   => false,
@@ -54,6 +56,7 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'VWSMail'              => '',
 					'disableCorePattern'   => false,
 					'disablePluginPattern' => false,
+					'disableXT9Pattern'    => false,
 					'account-check'        => array(
 						'date'                   => null,
 						'disable-empty-notice'   => false,

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -41,6 +41,8 @@ $vbp_prefix = apply_filters( 'vbp_prefix', 'VK ' );
  * @return $options オプション値の配列
  */
 function vbp_get_options() {
+	// デフォルト値.
+	// この値を追加した場合は ./test/test-get-options.php のテストを追記する.
 	$default = array(
 		'role'                 => 'author',
 		'showPatternsLink'     => true,
@@ -56,7 +58,8 @@ function vbp_get_options() {
 		),
 	);
 	$options = get_option( 'vk_block_patterns_options' );
-	// showPatternsLinkは後から追加したので、option値に保存されてない時にデフォルトとマージする
+	// 後から追加される項目もあるので、option値に保存されてない時にデフォルトとマージする
+	// ただし wp_parse_args は1階層目の内容しかきれいにマージしてくれないので注意.
 	$options = wp_parse_args( $options, $default );
 	return $options;
 }

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -47,7 +47,7 @@ function vbp_get_options() {
 		'VWSMail'              => '',
 		'disableCorePattern'   => false,
 		'disablePluginPattern' => false,
-		'disableXT9Pattern' => false,
+		'disableXT9Pattern'    => false,
 		'account-check'        => array(
 			'date'                   => null,
 			'disable-empty-notice'   => false,

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -35,6 +35,32 @@ define( 'VBP_URL', plugin_dir_url( __FILE__ ) );
 global $vbp_prefix;
 $vbp_prefix = apply_filters( 'vbp_prefix', 'VK ' );
 
+/**
+ * オプション値を取得して返す
+ * 
+ * @return $options オプション値の配列
+ */
+function vbp_get_options() {
+	$default = array(
+		'role'                 => 'author',
+		'showPatternsLink'     => true,
+		'VWSMail'              => '',
+		'disableCorePattern'   => false,
+		'disablePluginPattern' => false,
+		'disableXT9Pattern' => false,
+		'account-check'        => array(
+			'date'                   => null,
+			'disable-empty-notice'   => false,
+			'disable-invalid-notice' => false,
+			'disable-free-notice'    => false,
+		),
+	);
+	$options = get_option( 'vk_block_patterns_options' );
+	// showPatternsLinkは後から追加したので、option値に保存されてない時にデフォルトとマージする
+	$options = wp_parse_args( $options, $default );
+	return $options;
+}
+
 
 /**
  * Plugin Loaded
@@ -59,28 +85,6 @@ function vbp_set_plugin_meta( $links ) {
 	return $links;
 }
 add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), 'vbp_set_plugin_meta', 10, 1 );
-
-
-
-function vbp_get_options() {
-	$default = array(
-		'role'                 => 'author',
-		'showPatternsLink'     => true,
-		'VWSMail'              => '',
-		'disableCorePattern'   => false,
-		'disablePluginPattern' => false,
-		'account-check'        => array(
-			'date'                   => null,
-			'disable-empty-notice'   => false,
-			'disable-invalid-notice' => false,
-			'disable-free-notice'    => false,
-		),
-	);
-	$options = get_option( 'vk_block_patterns_options' );
-	// showPatternsLinkは後から追加したので、option値に保存されてない時にデフォルトとマージする
-	$options = wp_parse_args( $options, $default );
-	return $options;
-}
 
 $options = vbp_get_options();
 if ( ! empty( $options['disableCorePattern'] ) ) {


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-block-patterns/issues/131

## どういう変更をしたか？

* パターンライブラリの X-T9 のパターンを X-T9 カテゴリに追加


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. https://github.com/vektor-inc/vk-block-patterns/blob/e7670d5403d1ee74c9a0ce796c2ee56e33b828b2/favorite-patterns/favorite-patterns.php#L16
上記を `https://test.patterns.vektor-inc.co.jp/wp-json/vk-patterns/v1/status` に書き換え
2. 設定 > VK Block Patterns に進む
3. VWS のメールアドレスが何も入っていなければ X-T9 のパターンの有効・無効の切り替えは表示されない
4. VWS のメールアドレスに何か入っていれば X-T9 のパターンの有効・無効の切り替えは表示される
5.  X-T9 のパターンの有効ならパターンに X-T9 が表示されそうでなければ表示されない

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

1. https://github.com/vektor-inc/vk-block-patterns/blob/e7670d5403d1ee74c9a0ce796c2ee56e33b828b2/favorite-patterns/favorite-patterns.php#L16
上記を `https://test.patterns.vektor-inc.co.jp/wp-json/vk-patterns/v1/status` に書き換え
2. 設定 > VK Block Patterns に進む
3. VWS のメールアドレスが何も入っていなければ X-T9 のパターンの有効・無効の切り替えは表示されない
4. VWS のメールアドレスに何か入っていれば X-T9 のパターンの有効・無効の切り替えは表示される
5.  X-T9 のパターンの有効ならパターンに X-T9 が表示されそうでなければ表示されない

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
