### PR TITLE
【要再考】ログインチェック用のアラートを追加+α

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -209,7 +209,7 @@ function vbp_vws_alert_list() {
 	// VK Pattens Library にログインしていない場合
 	$not_logged_in = '<div class="notice notice-warning">';
 	$not_logged_in.= '<p>';
-	$not_logged_in.= 'VK Pattern Library にログインしていません。お気に入りパターンや X-T9 のパターンを利用するには VK Pattern Library にログインする必要があります。';
+	$not_logged_in.= '24 時間以内に VK Pattern Library にログインしていません。お気に入りパターンや X-T9 のパターンを利用するには 24 時間以内に VK Pattern Library にログインする必要があります。';
 	$not_logged_in.= '</p>';
 	$not_logged_in.= '<div style="margin-bottom:10px;">';
 	$not_logged_in.= '<a href="https://patterns.vektor-inc.co.jp/" class="button button-primary" target="_blank" rel="noopener noreferrer">VK Pattern Library にログインする</a>';

--- a/admin/admin.php
+++ b/admin/admin.php
@@ -206,11 +206,24 @@ function vbp_vws_alert_list() {
 	$empty_notice .= '</div>';
 	$empty_notice .= '</div>';
 
+	// VK Pattens Library にログインしていない場合
+	$not_logged_in = '<div class="notice notice-warning">';
+	$not_logged_in.= '<p>';
+	$not_logged_in.= 'VK Pattern Library にログインしていません。お気に入りパターンや X-T9 のパターンを利用するには VK Pattern Library にログインする必要があります。';
+	$not_logged_in.= '</p>';
+	$not_logged_in.= '<div style="margin-bottom:10px;">';
+	$not_logged_in.= '<a href="https://patterns.vektor-inc.co.jp/" class="button button-primary" target="_blank" rel="noopener noreferrer">VK Pattern Library にログインする</a>';
+	$not_logged_in.= ' ';
+	$not_logged_in.= '<a href="' . $current_url . $url_next . 'disable-not-logged-in-notice" class="button button-secondary">' . __( 'Dismiss', 'vk-block-patterns' ) . '</a>';
+	$not_logged_in.= '</div>';
+	$not_logged_in.= '</div>';
+
 	// 配列に整えて返す.
 	$alert = array(
-		'invalid-user' => $invalid_notice,
-		'free-user'    => $free_notice,
-		'empty-user'   => $empty_notice,
+		'invalid-user'  => $invalid_notice,
+		'free-user'     => $free_notice,
+		'empty-user'    => $empty_notice,
+		'not-logged-in' => $not_logged_in,
 	);
 
 	return $alert;
@@ -238,6 +251,8 @@ function vbp_vws_alert( $api = array() ) {
 					$notice = $alerts['invalid-user'];
 				} elseif ( 'free-user' === $role && false === $options['account-check']['disable-free-notice'] ) {
 					$notice = $alerts['free-user'];
+				} elseif ( 'not-logged-in' === $role && false === $options['account-check']['disable-not-logged-in-notice'] ) {
+					$notice = $alerts['not-logged-in'];
 				}
 			}
 		} elseif ( false === $options['account-check']['disable-empty-notice'] ) {
@@ -261,8 +276,9 @@ function vbp_admin_control() {
 		$checked_date = $options['account-check']['date'];
 		$diff_yaer    = ( strtotime( $current_date ) - strtotime( $checked_date ) ) / ( 60 * 60 * 24 * 365 );
 		if ( 1 <= $diff_yaer ) {
-			$options['account-check']['disable-invalid-notice'] = false;
-			$options['account-check']['disable-free-notice']    = false;
+			$options['account-check']['disable-invalid-notice']          = false;
+			$options['account-check']['disable-free-notice']             = false;
+			$options['account-check']['disable-not-logged-in-notice']    = false;
 		}
 	}
 
@@ -274,6 +290,9 @@ function vbp_admin_control() {
 	}
 	if ( isset( $_GET['disable-empty-notice'] ) ) {
 		$options['account-check']['disable-empty-notice'] = true;
+	}
+	if ( isset( $_GET['disable-not-logged-in-notice'] ) ) {
+		$options['account-check']['disable-not-logged-in-notice'] = true;
 	}
 	$options['account-check']['date'] = $current_date;
 	update_option( 'vk_block_patterns_options', $options );

--- a/favorite-patterns/favorite-patterns.php
+++ b/favorite-patterns/favorite-patterns.php
@@ -19,7 +19,7 @@ function vbp_get_pattern_api_data() {
 			array(
 				'timeout' => 10,
 				'body'    => array(
-					'login_id' => $user_email,
+					'login_mail' => $user_email,
 				),
 			)
 		);

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,8 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Fix ][ Japanese ] Fix API Alert.
+
 = 1.25.2 =
 [ Bug fix ] Fix Setting Page Layout bug ( vk admin 2.6.0 )
 

--- a/tests/test-alert.php
+++ b/tests/test-alert.php
@@ -145,6 +145,49 @@ class AlertTest extends WP_UnitTestCase {
 				),
 				'correct' => $alerts['free-user'],
 			),
+			/* ログインされていないのを検出した場合 */
+			// デフォルトの状態
+			array(
+				'option'  => array(
+					'VWSMail'                    => 'vk-support@vektor-inc.co.jp',
+					'account-check' => array(
+						'date'                         => null,
+						'disable-not-logged-in-notice' => false,
+					),
+				),
+				'api' => array(
+					'role' => 'not-logged-in'
+				),
+				'correct' => $alerts['not-logged-in'],
+			),
+			// 無効化されてから１年経過前
+			array(
+				'option'  => array(
+					'VWSMail'                    => 'vk-support@vektor-inc.co.jp',
+					'account-check' => array(
+						'date'                         => date( 'Y-m-d H:i:s', strtotime("-11 month") ),
+						'disable-not-logged-in-notice' => true,
+					),
+				),
+				'api' => array(
+					'role' => 'not-logged-in'
+				),
+				'correct' => '',
+			),
+			// 無効化されてから１年経過後
+			array(
+				'option'  => array(
+					'VWSMail'                    => 'vk-support@vektor-inc.co.jp',
+					'account-check' => array(
+						'date'                         => date( 'Y-m-d H:i:s', strtotime("-13 month") ),
+						'disable-not-logged-in-notice' => true,
+					),
+				),
+				'api' => array(
+					'role' => 'not-logged-in'
+				),
+				'correct' => $alerts['not-logged-in'],
+			),
 		);
 		print PHP_EOL;
 		print '------------------------------------' . PHP_EOL;

--- a/tests/test-get-options.php
+++ b/tests/test-get-options.php
@@ -20,10 +20,11 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'disablePluginPattern' => false,
 					'disableXT9Pattern'    => false,
 					'account-check'        => array(
-						'date'                   => null,
-						'disable-empty-notice'   => false,
-						'disable-invalid-notice' => false,
-						'disable-free-notice'    => false,
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+						'disable-not-logged-in-notice' => false,
 					),
 				),
 			),
@@ -39,10 +40,11 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'disablePluginPattern' => false,
 					'disableXT9Pattern'    => false,
 					'account-check'        => array(
-						'date'                   => null,
-						'disable-empty-notice'   => false,
-						'disable-invalid-notice' => false,
-						'disable-free-notice'    => false,
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+						'disable-not-logged-in-notice' => false,
 					),
 				),
 			),
@@ -59,10 +61,11 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'disablePluginPattern' => false,
 					'disableXT9Pattern'    => false,
 					'account-check'        => array(
-						'date'                   => null,
-						'disable-empty-notice'   => false,
-						'disable-invalid-notice' => false,
-						'disable-free-notice'    => false,
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+						'disable-not-logged-in-notice' => false,
 					),
 				),
 			),
@@ -90,10 +93,104 @@ class GetOptionsTest extends WP_UnitTestCase {
 					'disablePluginPattern' => true,
 					'disableXT9Pattern'    => false,
 					'account-check'        => array(
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+					),
+				),
+			),
+			array(
+				'option'  => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
 						'date'                   => null,
 						'disable-empty-notice'   => false,
 						'disable-invalid-notice' => false,
 						'disable-free-notice'    => false,
+					),
+				),
+				'correct' => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+					),
+				),
+			),
+			// ログインチェックが追加
+			array(
+				'option'  => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
+						'date'                   => null,
+						'disable-empty-notice'   => false,
+						'disable-invalid-notice' => false,
+						'disable-free-notice'    => false,
+					),
+				),
+				'correct' => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+					),
+				),
+			),
+			// ログインチェックが追加
+			array(
+				'option'  => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+						'disable-not-logged-in-notice' => false,
+					),
+				),
+				'correct' => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => '',
+					'disableCorePattern'   => true,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => false,
+					'account-check'        => array(
+						'date'                         => null,
+						'disable-empty-notice'         => false,
+						'disable-invalid-notice'       => false,
+						'disable-free-notice'          => false,
+						'disable-not-logged-in-notice' => false,
 					),
 				),
 			),
@@ -113,10 +210,10 @@ class GetOptionsTest extends WP_UnitTestCase {
 			$return  = vbp_get_options();
 			$correct = $test_value['correct'];
 
-			print 'return[\'role\']  :' . $return['role'] . PHP_EOL;
-			print 'correct[\'role\'] :' . $correct['role'] . PHP_EOL;
-			print 'return[\'showPatternsLink\']  :' . $return['showPatternsLink'] . PHP_EOL;
-			print 'correct[\'showPatternsLink\'] :' . $correct['showPatternsLink'] . PHP_EOL;
+			print 'return:' . PHP_EOL;
+			var_dump( $return );
+			print 'correct:' . PHP_EOL;
+			var_dump( $correct );
 			$this->assertEquals( $correct, $return );
 
 		}

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -51,10 +51,11 @@ function vbp_get_options() {
 		'disablePluginPattern' => false,
 		'disableXT9Pattern'    => false,
 		'account-check'        => array(
-			'date'                   => null,
-			'disable-empty-notice'   => false,
-			'disable-invalid-notice' => false,
-			'disable-free-notice'    => false,
+			'date'                         => null,
+			'disable-empty-notice'         => false,
+			'disable-invalid-notice'       => false,
+			'disable-free-notice'          => false,
+			'disable-not-logged-in-notice' => false,
 		),
 	);
 	$options = get_option( 'vk_block_patterns_options' );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-patterns/issues/209

## どういう変更をしたか？

- VK Patterns Library に 24 時間以内にログインしていない場合、ログインしていない旨の警告を出す
- API の login_id を login_mail に変更


## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. VK Block Patterns の fix/alert-2 ブランチの API を test. に向ける
2. kurudrive@gmail.com を VK Block Patterns の連携設定に設定
3. 設定後ブラウザを更新すると kurudrive@gmail.com は 24 時間以内にログインしていないのでその旨の警告が表示
4. kurudrive@gmail.com でログインするとログイン関連のメッセージは表示されなくなる
5. アラートの内容・オプションの中身は npm run phpunit で確認

## 確認URL

https://test.patterns.vektor-inc.co.jp (一応)

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

1. VK Block Patterns の API を test. に向ける
2. kurudrive@gmail.com を VK Block Patterns の連携設定に設定
3. 設定後ブラウザを更新すると kurudrive@gmail.com は 24 時間以内にログインしていないのでその旨の警告が表示
4. kurudrive@gmail.com でログインするとログイン関連のメッセージは表示されなくなる
5. アラートの内容・オプションの中身は npm run phpunit で確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
