### PR TITLE
【確認待ち】アンインストール時にオプション値を削除

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -94,6 +94,10 @@ function vkp_show_patterns_register_settings() {
 			'type'    => 'boolean',
 			'default' => false,
 		),
+		'savePluginData'    => array(
+			'type'    => 'boolean',
+			'default' => false,
+		),
 	);
 
 	foreach ( $default_option_settings as $key => $value ) {

--- a/readme.txt
+++ b/readme.txt
@@ -16,7 +16,9 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Specification Change ] Add uninstall.
 [ Specification Change ] Change to disable WordPress Default pattern on default setting
+
 
 = 1.25.6 =
 [ Bug fix ][ Fit column ] fix gap on edit screen

--- a/src/admin/index.js
+++ b/src/admin/index.js
@@ -22,12 +22,16 @@ const Admin = () => {
 		vkpOptions.disableCorePattern === '1' ? true : false;
 	const defaultDisablePluginPattern =
 		vkpOptions.disablePluginPattern === '1' ? true : false;
+	const savePluginData =
+		vkpOptions.savePluginData === '1' ? true : false;
+
 	const [ vkpOption, setVkpOption ] = useState( {
 		role: vkpOptions.role,
 		showPatternsLink: defaultShowPatternsLink,
 		VWSMail: vkpOptions.VWSMail,
 		disableCorePattern: defaultDisableCorePattern,
 		disablePluginPattern: defaultDisablePluginPattern,
+		savePluginData: savePluginData
 	} );
 
 	const updateOptionValue = ( newValue ) => {
@@ -295,6 +299,25 @@ const Admin = () => {
 									updateOptionValue( {
 										...vkpOption,
 										showPatternsLink: newValue,
+									} );
+								} }
+							/>
+						</section>
+
+						<section>
+							<h4>
+								{ __( 'Uninstall Setting', 'vk-block-patterns' ) }
+							</h4>
+							<ToggleControl
+								label={ __(
+									'When Uninstall This Plugin, Save Data of This Plugin',
+									'vk-block-patterns'
+								) }
+								checked={ vkpOption.savePluginData }
+								onChange={ ( newValue ) => {
+									updateOptionValue( {
+										...vkpOption,
+										savePluginData: newValue,
 									} );
 								} }
 							/>

--- a/tests/test-get-options.php
+++ b/tests/test-get-options.php
@@ -25,6 +25,7 @@ class GetOptionsTest extends WP_UnitTestCase {
 						'disable-invalid-notice' => false,
 						'disable-free-notice'    => false,
 					),
+					'savePluginData'       => false,
 				),
 			),
 			array(
@@ -44,6 +45,7 @@ class GetOptionsTest extends WP_UnitTestCase {
 						'disable-invalid-notice' => false,
 						'disable-free-notice'    => false,
 					),
+					'savePluginData'       => false,
 				),
 			),
 			array(
@@ -64,6 +66,7 @@ class GetOptionsTest extends WP_UnitTestCase {
 						'disable-invalid-notice' => false,
 						'disable-free-notice'    => false,
 					),
+					'savePluginData'       => false,
 				),
 			),
 			// X-T9 のパターン読み込みパラメーター追加.
@@ -95,6 +98,39 @@ class GetOptionsTest extends WP_UnitTestCase {
 						'disable-invalid-notice' => false,
 						'disable-free-notice'    => false,
 					),
+					'savePluginData'       => false,
+				),
+			),
+			array(
+				'option'  => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => 'info@gmail.com',
+					'disableCorePattern'   => false,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => true,
+					'account-check'        => array(
+						'date'                   => null,
+						'disable-empty-notice'   => false,
+						'disable-invalid-notice' => false,
+						'disable-free-notice'    => false,
+					),
+					'savePluginData'       => true,
+				),
+				'correct' => array(
+					'role'                 => 'editor',
+					'showPatternsLink'     => false,
+					'VWSMail'              => 'info@gmail.com',
+					'disableCorePattern'   => false,
+					'disablePluginPattern' => true,
+					'disableXT9Pattern'    => true,
+					'account-check'        => array(
+						'date'                   => null,
+						'disable-empty-notice'   => false,
+						'disable-invalid-notice' => false,
+						'disable-free-notice'    => false,
+					),
+					'savePluginData'       => true,
 				),
 			),
 		);

--- a/tests/test-uninstall.php
+++ b/tests/test-uninstall.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Class UninstallTest
+ *
+ * @package vk-block-patterns
+ */
+
+class UninstallTest extends WP_UnitTestCase {
+
+	public function test_delete_option() {
+		// オプション値の追加などがあった場合は $test_data の配列の中のデータを追加してテストを追加してください.
+		$test_data = array(
+            // savePluginDataが空の場合
+			array(
+                'option'  => array(
+                    'role'                 => 'editor',
+                    'showPatternsLink'     => false,
+                    'VWSMail'              => '',
+                    'disableCorePattern'   => false,
+                    'disablePluginPattern' => true,
+                    'account-check'        => array(
+                        'date'                   => null,
+                        'disable-empty-notice'   => false,
+                        'disable-invalid-notice' => false,
+                        'disable-free-notice'    => false,
+                    ),
+				),
+				'correct' => false
+			),
+            // savePluginDataが false の場合
+			array(
+				'option'  => array(
+                    'role'                 => 'editor',
+                    'showPatternsLink'     => false,
+                    'VWSMail'              => '',
+                    'disableCorePattern'   => false,
+                    'disablePluginPattern' => true,
+                    'account-check'        => array(
+                        'date'                   => null,
+                        'disable-empty-notice'   => false,
+                        'disable-invalid-notice' => false,
+                        'disable-free-notice'    => false,
+                    ),
+                    'savePluginData'       => false,
+				),
+				'correct' => false
+			),
+            // オプションが空の場合
+			array(
+				'option'  => array(
+                    'role'                 => 'editor',
+                    'showPatternsLink'     => false,
+                    'VWSMail'              => '',
+                    'disableCorePattern'   => false,
+                    'disablePluginPattern' => true,
+                    'account-check'        => array(
+                        'date'                   => null,
+                        'disable-empty-notice'   => false,
+                        'disable-invalid-notice' => false,
+                        'disable-free-notice'    => false,
+                    ),
+                    'savePluginData'     => true,
+				),
+				'correct' => array(
+                    'role'                 => 'editor',
+                    'showPatternsLink'     => false,
+                    'VWSMail'              => '',
+                    'disableCorePattern'   => false,
+                    'disablePluginPattern' => true,
+                    'account-check'        => array(
+                        'date'                   => null,
+                        'disable-empty-notice'   => false,
+                        'disable-invalid-notice' => false,
+                        'disable-free-notice'    => false,
+                    ),
+                    'savePluginData'     => true,
+				),
+			),
+		);
+		print PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		print 'vbp_uninstall' . PHP_EOL;
+		print '------------------------------------' . PHP_EOL;
+		foreach ( $test_data as $test_value ) {
+
+			if ( ! isset( $test_value['option'] ) ) {
+				delete_option( 'vk_block_patterns_options' );
+			} else {
+				update_option( 'vk_block_patterns_options', $test_value['option'] );
+			}
+
+            vbp_uninstall();
+			$return  = get_option( 'vk_block_patterns_options' );
+			$correct = $test_value['correct'];
+
+			print 'return  :'. PHP_EOL; 
+            var_dump( $return ). PHP_EOL;
+			print 'correct :' . PHP_EOL;
+            var_dump( $correct ) . PHP_EOL;
+			$this->assertEquals( $correct, $return );
+
+		}
+	}
+}

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -56,6 +56,7 @@ function vbp_get_options() {
 			'disable-invalid-notice' => false,
 			'disable-free-notice'    => false,
 		),
+		'savePluginData'  => false,
 	);
 	$options = get_option( 'vk_block_patterns_options' );
 	// 後から追加される項目もあるので、option値に保存されてない時にデフォルトとマージする

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -125,8 +125,6 @@ add_action( 'admin_menu', 'vbp_add_pattern_link' );
  */
 function vbp_uninstall() {
 
-	global $vbp_prefix;
-
 	$options = vbp_get_options();
 
 	// データを削除しないにチェックが入っていたら何もしない
@@ -134,46 +132,10 @@ function vbp_uninstall() {
 		return;
 	}
 
-	unregister_setting( 'vbp_setting', 'vk_block_patterns_options' );
-
 	// オプションを削除
+	unregister_setting( 'vbp_setting', 'vk_block_patterns_options' );	
 	delete_option( 'vk_block_patterns_options' );
 	delete_site_option( 'vk_block_patterns_options' );
 
-	// カスタム投稿と関係ないブロックパターンカテゴリを削除
-	unregister_block_pattern_category( 'vk-block-patterns' );
-	unregister_block_pattern_category( 'x-t9' );
-	unregister_block_pattern_category( 'vk-pattern-favorites' );
-
-	// パターンカテゴリを削除
-	$terms = get_terms(
-		array(
-			'taxonomy' => 'vk-block-patterns-category'
-		)
-	);
-
-	foreach ( $terms as $term ) {
-		unregister_block_pattern_category( 'vk-block-pattern-' . $term->ID );
-		wp_delete_term( $term->ID, 'vk-block-patterns-category' );
-	}
-
-	// パターンのデータを削除
-	$posts = get_posts(
-		array(
-			'posts_per_page'   => -1,
-			'post_type' => 'vk-block-patterns',
-		)    
-	);
-
-	foreach ( $posts as $post ) {
-		unregister_block_pattern( 'vk-block-patterns/pattern-' . $post->ID );
-		wp_delete_post( $post->ID, true );
-	}
-
-	// カスタム分類の登録解除
-	unregister_taxonomy( 'vk-block-patterns-category' );
-	
-	// 投稿タイプの登録解除
-	unregister_post_type( 'vk-block-patterns' );
 }
 register_uninstall_hook( __FILE__, 'vbp_uninstall' );

--- a/vk-block-patterns.php
+++ b/vk-block-patterns.php
@@ -119,3 +119,61 @@ function vbp_add_pattern_link() {
 	}
 }
 add_action( 'admin_menu', 'vbp_add_pattern_link' );
+
+/**
+ * アンインストール処理
+ */
+function vbp_uninstall() {
+
+	global $vbp_prefix;
+
+	$options = vbp_get_options();
+
+	// データを削除しないにチェックが入っていたら何もしない
+	if ( ! empty( $options['savePluginData'] ) ) {
+		return;
+	}
+
+	unregister_setting( 'vbp_setting', 'vk_block_patterns_options' );
+
+	// オプションを削除
+	delete_option( 'vk_block_patterns_options' );
+	delete_site_option( 'vk_block_patterns_options' );
+
+	// カスタム投稿と関係ないブロックパターンカテゴリを削除
+	unregister_block_pattern_category( 'vk-block-patterns' );
+	unregister_block_pattern_category( 'x-t9' );
+	unregister_block_pattern_category( 'vk-pattern-favorites' );
+
+	// パターンカテゴリを削除
+	$terms = get_terms(
+		array(
+			'taxonomy' => 'vk-block-patterns-category'
+		)
+	);
+
+	foreach ( $terms as $term ) {
+		unregister_block_pattern_category( 'vk-block-pattern-' . $term->ID );
+		wp_delete_term( $term->ID, 'vk-block-patterns-category' );
+	}
+
+	// パターンのデータを削除
+	$posts = get_posts(
+		array(
+			'posts_per_page'   => -1,
+			'post_type' => 'vk-block-patterns',
+		)    
+	);
+
+	foreach ( $posts as $post ) {
+		unregister_block_pattern( 'vk-block-patterns/pattern-' . $post->ID );
+		wp_delete_post( $post->ID, true );
+	}
+
+	// カスタム分類の登録解除
+	unregister_taxonomy( 'vk-block-patterns-category' );
+	
+	// 投稿タイプの登録解除
+	unregister_post_type( 'vk-block-patterns' );
+}
+register_uninstall_hook( __FILE__, 'vbp_uninstall' );


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）
https://github.com/vektor-inc/vk-block-patterns/issues/107

## どういう変更をしたか？

- アンインストール時にオプション値を削除
- アンインストール時にオプションを削除しない設定も一応追加

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [x] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [x] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

- npm run phpunit で通常だとオプション値が削除されるのを確認しました。
- 実際に試して仕様通り動くのも確認しました。

## 確認URL

ローカル環境

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

- npm run phpunit で通常だとオプション値が削除されるのを確認
- 実際に試して仕様通り動くのか確認

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
