### PR TITLE
[ Bug fix ] Cope with failer of get_post_type_object() ( For example, when a post type is deleted )

### DIFF
--- a/inc/vk-block-patterns/package/class-vk-block-patterns.php
+++ b/inc/vk-block-patterns/package/class-vk-block-patterns.php
@@ -187,17 +187,22 @@ if ( ! class_exists( 'VK_Block_Patterns' ) ) {
 				// 新規投稿時の自動挿入の場合.
 				// For automatic insertion on new post.
 				if ( 'add' === $registered_pattern_add_method && $registered_post_type ) {
-					// 対象の投稿タイプを指定.
+
 					$post_type_object = get_post_type_object( $registered_post_type );
-					// パターンをテンプレートに挿入.
-					$post_type_object->template = array(
-						array(
-							'core/pattern',
+
+					// Cope with failer of get_post_type_object().
+					// * For example, if the post type is later deleted.
+					if ( ! empty( $post_type_object ) ) {
+						// Insert Block Pattern.
+						$post_type_object->template = array(
 							array(
-								'slug' => 'vk-block-patterns/pattern-' . esc_attr( get_the_ID() ),
+								'core/pattern',
+								array(
+									'slug' => 'vk-block-patterns/pattern-' . esc_attr( get_the_ID() ),
+								),
 							),
-						),
-					);
+						);
+					}
 				}
 
 				// 新規投稿時の候補の表示.

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,8 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Bug fix ] Cope with failer of get_post_type_object() ( For example, when a post type is deleted )
+
 = 1.30.2 =
 [ Bug fix ] Fix in case of specify default post type ,can't use on the other post type
 [ Bug fix ] Fix where selecting 'Unspecified' for 'How to Add Patterns.' would return to 'Show in Candidate'.


### PR DESCRIPTION
https://wordpress.org/support/topic/attempt-to-assign-property-template-on-null

It could be the case below.

1. Create custom post type AAA
2. Add pattern by VK Block Patterns and set to the default post type target to AAA
3. Delete post type AAA