### PR TITLE
[ 仕様変更 ] パターンライブラリのメール未登録のアラートを一旦非表示に変更

### DIFF
--- a/admin/admin.php
+++ b/admin/admin.php
@@ -205,16 +205,17 @@ function vbp_vws_alert_list() {
 	$free_notice .= '</div>';
 
 	// メールアドレスが入力されていない場合.
-	$empty_notice  = '<div class="notice notice-warning">';
-	$empty_notice .= '<p>';
-	$empty_notice .= 'VK Pattern Library のアカウント連携が設定されていません。';
-	$empty_notice .= '</p>';
-	$empty_notice .= '<div style="margin-bottom:10px;">';
-	$empty_notice .= '<a href="' . $setting_link . '" class="button button-primary">' . __( 'Go to VK Block Patterns Setting', 'vk-block-patterns' ) . '</a>';
-	$empty_notice .= ' ';
-	$empty_notice .= '<a href="' . $current_url . $url_next . 'disable-empty-notice" class="button button-secondary">' . __( 'Dismiss', 'vk-block-patterns' ) . '</a>';
-	$empty_notice .= '</div>';
-	$empty_notice .= '</div>';
+	$empty_notice  = '';
+	// $empty_notice .= '<div class="notice notice-warning">';
+	// $empty_notice .= '<p>';
+	// $empty_notice .= 'VK Pattern Library のアカウント連携が設定されていません。';
+	// $empty_notice .= '</p>';
+	// $empty_notice .= '<div style="margin-bottom:10px;">';
+	// $empty_notice .= '<a href="' . $setting_link . '" class="button button-primary">' . __( 'Go to VK Block Patterns Setting', 'vk-block-patterns' ) . '</a>';
+	// $empty_notice .= ' ';
+	// $empty_notice .= '<a href="' . $current_url . $url_next . 'disable-empty-notice" class="button button-secondary">' . __( 'Dismiss', 'vk-block-patterns' ) . '</a>';
+	// $empty_notice .= '</div>';
+	// $empty_notice .= '</div>';
 
 	// 配列に整えて返す.
 	$alert = array(

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,8 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Specification Change ] Temporarily hide the alert about the unregistered email in the pattern library.
+
 = 1.33.1 =
 [ Bug fix ][ 6.8 ] Adapt to the Cover block specification changes in WordPress 6.8
 


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

このプラグインをインストール・有効化すると、
パターンライブラリのメールアドレスが未登録だとアラートが表示されるようになっている。
しかしながら、実際連携してもそんなに便利じゃないしイ現状では連携のメリットが少ないわりに、
知らない・よくわからない人にはアラートが出続ける（Dismissボタンで消せるけど押せない人が多い）のでとりあえず一旦非表示に変更

## どういう変更をしたか？

アラートメッセージを空にしてコメントアウト
※連携の形態を変更して復活させる可能性があるため

## 実装者の確認事項

実装者はレビュワーに回す前に以下の事を確認してチェックをつけてください。

- [ ] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] Files changed (変更ファイル)の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。

- [ ] 書けそうなテストは書いたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

実装者が確認した手順を箇条書きで記載してください。

*
*
*

## レビュワーに回す前の確認事項

- [ ] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

レビュワーがどういう手順で何を確認して欲しいかを記載してください。

*
*
*

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

レビューしてみて意図した動作をしない場合は再度ビルドするなど以下の項目を確認してください。

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？
