### PR TITLE
[ 不具合修正 ] dist処理変更の影響でパターンの画像が壊れるリンク切れになる不具合を修正

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -42,6 +42,9 @@ gulp.task('dist', function () {
 	  ], {
 		base: './',
 		allowEmpty: true,
+		// Gulp 5 ではデフォルトの encoding が utf8 に変更されたため、
+		// バイナリファイル（画像など）が破損する。encoding: false を指定して回避する。
+		encoding: false,
 	  }
 	).pipe(gulp.dest("dist/vk-block-patterns"));
   });

--- a/readme.txt
+++ b/readme.txt
@@ -15,6 +15,8 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Bug Fix ] Fix pattern images being corrupted during dist build process due to Gulp 5 encoding change
+
 = 1.35.0 =
 [ Add Function ] Enable theme patterns for all themes, not only X-T9.
 


### PR DESCRIPTION
## 概要

パターンに内包される画像ファイル（PNG, JPG 等）が dist 処理の過程で壊れる問題を修正しました。

## 原因

Gulp 5 ではデフォルトの encoding が `utf8` に変更されたため、`gulp.src` でバイナリファイル（画像）をコピーする際にファイルが破損していました。

## 修正内容

`gulpfile.js` の `gulp.src` オプションに `encoding: false` を追加し、バイナリファイルがそのままコピーされるようにしました。

## テスト

- `npm run dist` を実行し、`dist/vk-block-patterns/` 配下の画像ファイルが壊れていないことを確認する
- dist 前後の画像ファイルのサイズが一致することを確認する

Fixes #254

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* dist ビルドプロセス中にパターン画像が破損する問題を修正しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->