### PR TITLE
[ 不具合修正 ] npm run dist で生成される zip の内部パスに dist/ が含まれる問題を修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,8 +42,8 @@ jobs:
           key: ${{ runner.os }}-php${{ matrix.php-versions }}-${{ hashFiles('**/composer.lock') }}
       - name: Install dependencies
         run: npm install && composer install
-      - name: Create dist
-        run: npm run dist
+      - name: Create dist & zip
+        run: npm run zip
       - name: Upload dist artifact
         if: matrix.php-versions == '8.3' && matrix.wp-versions == '6.9'
         uses: actions/upload-artifact@v4

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
 		"upgrade": "ncu -u --target latest && rimraf node_modules/ package-lock.json && npm install",
 		"watch": "wp-scripts start",
 		"build": "wp-scripts build && npm run build:sass",
-		"dist": "npm run build && composer install --no-dev && gulp dist && composer install && npm run zip",
+		"dist": "npm run build && composer install --no-dev && gulp dist && composer install",
 		"build:sass": "sass --style=compressed --no-source-map patterns-data/_scss:patterns-data && sass --style=compressed --no-source-map inc/vk-block-patterns/package:inc/vk-block-patterns/package",
 		"sass": "sass --watch patterns-data/_scss:patterns-data",
 		"lint": "wp-scripts format src/ && wp-scripts lint-js src/ --fix",
 		"wp-env": "wp-env",
 		"phpunit": "wp-env run tests-cli --env-cwd='wp-content/plugins/vk-block-patterns' vendor/bin/phpunit -c .phpunit.xml",
-		"zip": "bestzip dist/vk-block-patterns.zip dist/vk-block-patterns"
+		"zip": "npm run dist && cd dist && bestzip vk-block-patterns.zip vk-block-patterns"
 	},
 	"repository": {
 		"type": "git",


### PR DESCRIPTION
## 概要

`npm run dist` で生成される zip ファイルの内部パスに `dist/` プレフィックスが含まれてしまい、解凍すると `dist/vk-block-patterns/` というネスト構造になる問題を修正しました。

## 変更内容

- **package.json**: `dist` スクリプトから zip 処理を分離し、ビルドとファイル配置のみに変更
- **package.json**: `zip` スクリプトを `npm run dist && cd dist && bestzip vk-block-patterns.zip vk-block-patterns` に変更し、`dist/` ディレクトリ内で bestzip を実行することで正しいパス構造の zip を生成
- **release.yml**: `npm run dist` を `npm run zip` に変更（リリース時に zip が必要なため）

## テスト手順

1. `npm run zip` を実行
2. 生成された `dist/vk-block-patterns.zip` を解凍
3. 解凍先が `vk-block-patterns/` であること（`dist/vk-block-patterns/` ではないこと）を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ビルドおよびパッケージング処理のワークフローを最適化しました。
  * CI/CDパイプラインの配布物作成ステップを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->