### PR TITLE
[ 不具合修正 ] readme.txt に Stable tag を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: Guternberg, Block Pattern
 Requires at least: 6.5
 Tested up to: 6.9
 Requires PHP: 7.4
+Stable tag: 1.35.2
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## 概要

- `readme.txt` に `Stable tag: 1.35.2` を追加

## 背景

`Stable tag` ヘッダーが欠落していたため、WordPress.org のビルドシステムがタグディレクトリではなく trunk からプラグイン zip を生成していました。これにより、1.35.2 リリース後も更新時に 1.35.1 のファイルが配信される問題が発生していました。

## テスト

- [ ] SVN に反映後、WordPress.org からダウンロードされる zip の中身が 1.35.2 であることを確認


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **チョア**
  * プラグインの readme ファイルが更新され、バージョン 1.35.2 が安定版として明示されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->