### PR TITLE
[ 不具合修正 ] ウィジェット編集画面で vbp-editor-panel スクリプトが読み込まれて PHP notice が記録される不具合を修正

### DIFF
--- a/inc/vk-block-patterns/package/class-add-meta-box.php
+++ b/inc/vk-block-patterns/package/class-add-meta-box.php
@@ -193,7 +193,26 @@ class AddMetaBox {
 		return true;
 	}
 
+	/**
+	 * ブロックエディター用スクリプト・スタイルを読み込む
+	 * Load scripts and styles for the block editor.
+	 *
+	 * 投稿タイプのあるブロックエディター画面でのみ実行する。
+	 * ウィジェット編集画面（wp-edit-widgets / wp-customize-widgets）では
+	 * wp-editor ハンドルを enqueue すると PHP notice が発生するため除外する。
+	 * Only runs on block editor screens with a post type.
+	 * Skips widget editor screens to avoid the PHP notice caused by enqueuing wp-editor.
+	 *
+	 * @return void
+	 */
 	public static function enqueue_scripts() {
+		// 投稿タイプのあるブロックエディター画面以外では処理しない。
+		// Skip if not on a block editor screen that has a post type.
+		$screen = get_current_screen();
+		if ( ! $screen || ! $screen->is_block_editor || empty( $screen->post_type ) ) {
+			return;
+		}
+
 		wp_enqueue_style(
 			'vk-block-patterns-editor',
 			plugins_url( '/editor.css', __FILE__ ),

--- a/readme.txt
+++ b/readme.txt
@@ -16,6 +16,9 @@ When you activate this plugin that create new custom post type for custom block 
 
 == Changelog ==
 
+[ Bug Fix ] Fixed an issue where the vbp-editor-panel script was loaded on the widget editor screen, causing a PHP notice about wp-editor being enqueued.
+[ 不具合修正 ] ウィジェット編集画面で vbp-editor-panel スクリプトが読み込まれて PHP notice が記録される不具合を修正。
+
 [ Bug Fix ] Fixed the settings screen admin CSS/JS not refreshing in the browser after an update, and the left sidebar navigation being clipped when admin notices appear.
 
 = 1.36.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,6 @@ When you activate this plugin that create new custom post type for custom block 
 == Changelog ==
 
 [ Bug Fix ] Fixed an issue where the vbp-editor-panel script was loaded on the widget editor screen, causing a PHP notice about wp-editor being enqueued.
-[ 不具合修正 ] ウィジェット編集画面で vbp-editor-panel スクリプトが読み込まれて PHP notice が記録される不具合を修正。
 
 [ Bug Fix ] Fixed the settings screen admin CSS/JS not refreshing in the browser after an update, and the left sidebar navigation being clipped when admin notices appear.
 

--- a/tests/test-metabox.php
+++ b/tests/test-metabox.php
@@ -48,4 +48,46 @@ class AddMetaBoxTest extends WP_UnitTestCase {
 
 		}
 	}
+
+	/**
+	 * Current_screen が null の時は何もエンキューしない。
+	 * Does nothing when current_screen is null.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_scripts_guard_no_screen() {
+		$GLOBALS['current_screen'] = null;
+		VKBlockPatterns\AddMetaBox::enqueue_scripts();
+		$this->assertFalse( wp_style_is( 'vk-block-patterns-editor', 'enqueued' ) );
+	}
+
+	/**
+	 * Is_block_editor が false の時は何もエンキューしない。
+	 * Does nothing when is_block_editor is false.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_scripts_guard_not_block_editor() {
+		$screen                    = WP_Screen::get( 'widgets' );
+		$screen->is_block_editor   = false;
+		$GLOBALS['current_screen'] = $screen;
+		VKBlockPatterns\AddMetaBox::enqueue_scripts();
+		$this->assertFalse( wp_style_is( 'vk-block-patterns-editor', 'enqueued' ) );
+		$GLOBALS['current_screen'] = null;
+	}
+
+	/**
+	 * Post_type が空の時は何もエンキューしない。
+	 * Does nothing when post_type is empty.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_scripts_guard_empty_post_type() {
+		$screen                    = WP_Screen::get( 'widgets' );
+		$screen->is_block_editor   = true;
+		$GLOBALS['current_screen'] = $screen;
+		VKBlockPatterns\AddMetaBox::enqueue_scripts();
+		$this->assertFalse( wp_style_is( 'vk-block-patterns-editor', 'enqueued' ) );
+		$GLOBALS['current_screen'] = null;
+	}
 }

--- a/tests/test-metabox.php
+++ b/tests/test-metabox.php
@@ -11,6 +11,37 @@
 class AddMetaBoxTest extends WP_UnitTestCase {
 
 	/**
+	 * Saved current_screen value restored after each test.
+	 *
+	 * @var WP_Screen|null
+	 */
+	private $_original_screen;
+
+	/**
+	 * Save the original current_screen before each test.
+	 *
+	 * @return void
+	 */
+	public function setUp(): void {
+		parent::setUp();
+		$this->_original_screen = isset( $GLOBALS['current_screen'] )
+			? $GLOBALS['current_screen']
+			: null;
+	}
+
+	/**
+	 * Restore current_screen and dequeue test styles after each test.
+	 *
+	 * @return void
+	 */
+	public function tearDown(): void {
+		$GLOBALS['current_screen'] = $this->_original_screen;
+		wp_dequeue_style( 'vk-block-patterns-editor' );
+		wp_deregister_style( 'vk-block-patterns-editor' );
+		parent::tearDown();
+	}
+
+	/**
 	 * AddMetaBox::is_method_selected test.
 	 */
 	public function test_is_method_selected() {
@@ -47,6 +78,21 @@ class AddMetaBoxTest extends WP_UnitTestCase {
 			$this->assertEquals( $test['expected'], $actual );
 
 		}
+	}
+
+	/**
+	 * Is_block_editor が true かつ post_type がある時に style がエンキューされる。
+	 * Enqueues style when is_block_editor is true and post_type is set.
+	 *
+	 * @return void
+	 */
+	public function test_enqueue_scripts_happy_path() {
+		$screen                    = WP_Screen::get( 'post' );
+		$screen->is_block_editor   = true;
+		$screen->post_type         = 'post';
+		$GLOBALS['current_screen'] = $screen;
+		VKBlockPatterns\AddMetaBox::enqueue_scripts();
+		$this->assertTrue( wp_style_is( 'vk-block-patterns-editor', 'enqueued' ) );
 	}
 
 	/**


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

関連Issue: vektor-inc/multi-repo-tasks#25

## どういう変更をしたか？

`enqueue_block_editor_assets`（ブロックエディター用アセット読み込みフック）は投稿編集画面だけでなく、ウィジェット編集画面（`widgets.php`）でも発火します。`vbp-editor-panel` スクリプトのビルド依存（`build/editor-panel/index.asset.php` の `dependencies`）に `wp-editor` が含まれているため、ウィジェット編集画面でもこのスクリプトが読み込まれて以下の notice が記録されていました。

```
PHP Notice: 関数 wp_enqueue_script() が誤って呼び出されました。wp-editor スクリプトを新しいウィジェットエディター (wp-edit-widgets または wp-customize-widgets) と一緒にエンキューしないでください。
```

`enqueue_scripts()` の先頭に `get_current_screen()` を使った画面判定を追加し、投稿タイプのあるブロックエディター画面（投稿・固定ページ等）でのみスクリプトを読み込むよう修正しました。Lightning テーマの既存実装（`_g3/inc/layout-controller/admin-post-meta.php`）と同型のガードです。

**変更ファイル:**
- `inc/vk-block-patterns/package/class-add-meta-box.php` — `enqueue_scripts()` にスクリーンガード追加

## 実装者の確認事項

- [x] 複数の意図の変更（機能の不具合修正 + 別の機能追加など）を含んでいないか？
- [x] Files changed (変更ファイル) の内容は目視で確認したか？
- [x] readme.txt に変更内容は書いたか？
- [x] 本当にちゃんと確認をしたか？

## プログラムの変更の場合

- [x] 書けそうなテストは書いたか？

`get_current_screen()` のスクリーンガードをテストするには `WP_Screen` オブジェクトの `is_block_editor` / `post_type` プロパティのモック制御が必要で、現在のテスト構成では複雑度が高いためスキップしています。

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

**Before（修正前の再現手順）:**

**前提:** プラグインで vk-block-patterns のみ有効化する。WP_DEBUG / WP_DEBUG_LOG を有効にする

1. master ブランチの状態で、管理画面の「外観 > ウィジェット」を開く
2. `wp-content/debug.log` を確認する
→ `PHP Notice: 関数 wp_enqueue_script() が誤って呼び出されました。wp-editor スクリプトを...` が記録されている

**After（修正後の確認手順）:**

1. このブランチの変更を適用した状態で、管理画面の「外観 > ウィジェット」を開く
2. `wp-content/debug.log` を確認する
→ 上記 notice が記録されなくなっている

**デグレ確認:**

1. 管理画面の「投稿 > 新規追加」でブロックエディターを開く
2. ドキュメントサイドバーに「Initial pattern setting」パネルが表示されることを確認する
→ 投稿編集画面では引き続きサイドバーパネルが正常に表示される

## レビュワーに回す前の確認事項

- [x] 実装者はこのテンプレートのチェック項目をちゃんと確認してチェックしたか？

## レビュワー確認方法・確認内容など

* `WP_DEBUG=true` の環境でウィジェット編集画面を開き `debug.log` に notice が記録されなくなっていることを確認する
* 投稿編集画面でサイドバーパネルが正常に表示されることを確認する（デグレ確認）

---

## レビュワー向け

### レビュワーが確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
* キャッシュをクリアして確認したか？


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ブロックエディター以外の画面や投稿タイプ未設定時に、不要な読み込み処理が走らないよう改善しました。
  * ウィジェット編集画面で発生していた PHP notice を回避しました。
* **Documentation**
  * 変更内容を更新し、修正点を追記しました。
* **Tests**
  * 条件未成立時にスタイルが読み込まれないことを確認するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->