### PR TITLE
[ 開発環境 ] release.yml: dist スモークテストの wp-env override を .wp-env.override.json に修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,7 +52,7 @@ jobs:
           path: dist/
       - name: Create wp-env override for dist smoke test
         run: |
-          printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > wp-env.override.json
+          printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > .wp-env.override.json
       - name: Start wp-env (dist)
         run: |
           n=0


### PR DESCRIPTION
## 概要

リリースワークフロー（`.github/workflows/release.yml`）の C-7 移行不備を修正します。dist スモークテスト用の wp-env override を書き出す際、先頭ドット無しの `wp-env.override.json` に出力していました。wp-env は先頭ドット有りの `.wp-env.override.json` しか読み込まないため、この override が無効化され、**dist ではなく source（`.wp-env.json` の `plugins: ["."]`）を検証していた状態** になっていました。

書き出し先を `.wp-env.override.json`（ドット有り）に修正し、dist（`./dist/vk-block-patterns`）を正しくスモークテストできるようにします。

## 変更内容

- `release.yml` の「Create wp-env override for dist smoke test」ステップの出力先を `wp-env.override.json` → `.wp-env.override.json` に修正（1行）

## WP-CLI 導入について（対応不要と判断）

元 issue のもう1つの項目「WP-CLI 導入の要否」は、実ファイルを確認した結果 **対応不要** と判断しました。

- `release.yml` が実行する build/dist（`npm run zip` → `dist` = `wp-scripts build` + `composer install` + `gulp dist`）は host の `wp` コマンドに依存しない
- `gulp dist` は単なるファイルコピーで `wp i18n make-pot` を呼ばない。`package.json` に `translate` スクリプトや make-pot も存在しない
- `npm run phpunit` は wp-env コンテナ内 CLI を使用し、host の `wp` は不要

したがって release.yml に WP-CLI 導入ステップは不要です。

## changelog について

GitHub Actions ワークフロー設定の変更のため、changelog（`readme.txt`）への追記は不要です（`rules/changelog.md`「更新不要なケース: GitHub Actions などのワークフロー設定」）。エンドユーザーへの Fatal error 等の影響はなく、CI の検証対象の是正です。

## テスト（確認手順）

このワークフローはタグ push（`x.y.z`）時のみ発火するため、通常の PR では実行されません。差分の妥当性は次の観点で確認できます。

1. `.github/workflows/release.yml` の該当行を確認する
   → `printf '{"plugins": ["./dist/%s"]}' "${{ env.plugin_name }}" > .wp-env.override.json`（**先頭ドット有り**）になっていること
2. wp-env の override 命名規約を確認する
   → wp-env が読み込む override は `.wp-env.override.json`（先頭ドット有り）であること。ドット無しの `wp-env.override.json` は読み込まれない
3. （リリース時の実挙動）次回リリースの `Deploy to WordPress.org` ワークフローで、`Start wp-env (dist)` → `Smoke Test (dist)` が `./dist/vk-block-patterns`（dist）に対して実行されること

関連 issue: https://github.com/vektor-inc/vk-block-patterns/issues/266

---

**Task-queue:** https://github.com/vektor-inc/task-queue/issues/280